### PR TITLE
improve package listing display

### DIFF
--- a/bropkg/src/Model/Entity/Package.php
+++ b/bropkg/src/Model/Entity/Package.php
@@ -31,4 +31,16 @@ class Package extends Entity
         '*' => true,
         'id' => false
     ];
+
+    protected function _getBasename()
+    {
+        $parts = explode("/", $this->_properties['name']);
+        return end($parts);
+    }
+    protected function _getAuthor()
+    {
+        $parts = explode("/", $this->_properties['name']);
+        return $parts[1];
+    }
+
 }

--- a/bropkg/src/Template/Packages/index.ctp
+++ b/bropkg/src/Template/Packages/index.ctp
@@ -16,34 +16,17 @@
 </nav>
 <div class="packages index large-9 medium-8 columns content">
     <h3><?= __('Packages') ?></h3>
-    <table cellpadding="0" cellspacing="0">
-        <thead>
-            <tr>
-                <th scope="col"><?= $this->Paginator->sort('name') ?></th>
-                <th scope="col"><?= $this->Paginator->sort('url') ?></th>
-            </tr>
-        </thead>
-        <tbody style="border-bottom: 1px solid teal">
-            <?php foreach ($packages as $package): ?>
-            <tr>
-                <table cellpadding="0" cellspacing="0" style="border: 1px
-                solid teal; margin-bottom: 5px">
-                <tr>
-                <td><?= $this->Html->link($package->name, 
-                ['action' => 'view', $package->id]) ?></td>
-                <td><?= $this->Html->link($package->url, $package->url, 
-                ['target' => '_blank']) ?></td>
-                </tr>
-                <tr style="border-bottom: 1px solid teal">
-                <td colspan="2" style="white-space: nowrap; text-overflow:ellipsis; overflow: hidden; max-width:1px;">
-                <?= $package->metadatas[0]->description ?>
-                </td>
-                </tr>
-                </table>
-            </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
+    <?php foreach ($packages as $package): ?>
+    <div class="packagebox">
+        <h4> <?= $this->Html->link($package->basename, ['action' => 'view', $package->id]) ?>
+        </h4>
+        <p>
+            By <?= $this->Html->link($package->author, ['action' => 'index', '?' =>  ['q' => $package->author]]) ?>
+        <p>
+        <?= $package->metadatas[0]->description ?>
+        </p>
+    </div>
+    <?php endforeach; ?>
     <div class="paginator">
         <ul class="pagination">
             <?= $this->Paginator->first('<< ' . __('first')) ?>

--- a/bropkg/src/Template/Packages/view.ctp
+++ b/bropkg/src/Template/Packages/view.ctp
@@ -36,12 +36,21 @@ function strClean($str) {
 <?= $this->Html->scriptend(); ?>
 
 <div class="packages view large-9 medium-8 columns content">
-    <h3><?= h($package->name) ?></h3>
+    <h3><?= h($package->basename) ?></h3>
 
     <div class="row">
-         <h4><?= __('URL :') ?></h4>
          <?= $this->Html->link($package->url, $package->url, ['target' => '_blank']) ?>
     </div>
+
+    <?php if (!empty($package->readme)): ?>
+        <p></p>
+        <div class="row">
+            <article class="markdown-body entry-content" itemprop="text">
+            <?= $this->Markdown->transform($package->readme); ?>
+            </article>
+        </div>
+    <?php endif; ?>
+
 
     <?php if (!empty($package->metadatas)): ?>
 
@@ -153,16 +162,6 @@ function strClean($str) {
                     <?php endif; ?>
                 </div>
             <?php endforeach; ?>
-        </div>
-    <?php endif; ?>
-
-    <?php if (!empty($package->readme)): ?>
-        <p></p>
-        <div class="row">
-            <h4><?= __('README :') ?></h4>
-            <article class="markdown-body entry-content" itemprop="text">
-            <?= $this->Markdown->transform($package->readme); ?>
-            </article>
         </div>
     <?php endif; ?>
 

--- a/bropkg/webroot/css/bro.css
+++ b/bropkg/webroot/css/bro.css
@@ -17,7 +17,7 @@ li.search {
   color: teal;
   display: inline;
   padding-bottom: 0;
-  border-bottom: 1px solid teal;
+  border-bottom: none;
 }
 select.div-toggle {
   width: 20%;
@@ -25,4 +25,11 @@ select.div-toggle {
 .markdown-body {
   margin: 10px;
   padding: 10px;
+}
+
+.packagebox {
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    margin-bottom: 20px;
+    padding: 10px 10px 0px 10px;
 }


### PR DESCRIPTION
This tries to make the package listing/display a little more user
friendly.  The primary way it does this is by separating a package name
like

bro/user/package into 'package' and 'user' so they can be displayed
separately.  The import process could probably do this step a little
better.

This still needs a bit of work but it's a start.  I couldn't get the
fontawesome stuff to work and couldn't figure out which version of
'primer' is present.