### PR TITLE
Install python via pyenv on php docker image

### DIFF
--- a/cronjob/bro-pkg-web-updater.php
+++ b/cronjob/bro-pkg-web-updater.php
@@ -9,7 +9,7 @@
 $envfile = '/var/www/html/config/.env';
 
 // Set the location of the zkg command line exec
-$zkg_exec = '/usr/local/bin/zkg';
+$zkg_exec = '/root/uv-venv/bin/zkg';
 
 function fatal($msg) {
     echo "$msg\n";


### PR DESCRIPTION
When we upgraded all of the Zeek projects to Python 3.9, we overlooked that the base image that zeek-pkg-web php setup runs on is based on Debian 10. Because of this, we can't upgrade the default version of Python past version 3.7. We made recent changes to zkg to speed up querying packages to fix a problem on zeek-pkg-web, except we can't install that new version (3.1.0) because of the version requirement.

This PR works around this by installing a new version of Python (3.13) using `pyenv`, and then installs zkg via that. It requires a bunch of new dev dependencies in order to build Python unfortunately. I confirmed that this fixes the installation issue with zkg on a local installation of zeek-pkg-web:

```
root@ad711fc5efa3:/var/www/html# python --version
Python 3.13.6
root@ad711fc5efa3:/var/www/html# which zkg
/root/.pyenv/shims/zkg
root@ad711fc5efa3:/var/www/html# zkg --version
zkg 3.1.0
```

Updating packages completes successfully. We're now able to see the `esnet/zeek-exporter` package, which was the original impetus for the fixes to zkg.

Hopefully once I get zeek-pkg-web updated to php 8, we can drop all of this as the new base image supports a higher version of Python by default.