### PR TITLE
Disable link underlines globally

### DIFF
--- a/bropkg/webroot/css/zeek.css
+++ b/bropkg/webroot/css/zeek.css
@@ -6,6 +6,9 @@
     padding-right: 7rem !important;
     padding-left: 7rem !important;
 }
+.container a {
+    text-decoration: none;
+}
 
 body {
     background-color: aliceblue;
@@ -43,11 +46,6 @@ select.div-toggle {
     margin-bottom: 20px;
     padding: 10px 10px 0px 10px;
     background-color: white;
-    text-decoration: none;
-}
-
-.packages a {
-    text-decoration: none;
 }
 
 a {


### PR DESCRIPTION
I noticed that the index page still had underlines on links after deploying https://github.com/zeek/zeek-pkg-web/pull/15 onto packages-test post-merge. This changes the CSS to just disable link underlines globally on any link within the outer `container` div. It also removes a couple of CSS rules that are obsoleted by this change.