### PR TITLE
Make sure composer is ok running during 'docker build'

### DIFF
--- a/docker/Dockerfile.php
+++ b/docker/Dockerfile.php
@@ -59,6 +59,13 @@ RUN docker-php-ext-install \
     intl \
     zip
 
+# Composer really doesn't like running as root and complains when you do.
+# It also makes a best effort to detect running in docker container so it
+# can allow that, but sometimes it misses it and things don't work right.
+# Force it to allow running as root so that PHP plugins are loaded
+# correctly. See https://getcomposer.org/doc/faqs/how-to-install-untrusted-packages-safely.md#running-composer-inside-docker-podman-containers for more detail.
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 COPY --from=composer:2.8 /usr/bin/composer /usr/bin/composer
 COPY bropkg/composer.json .
 RUN composer install


### PR DESCRIPTION
This didn't pop up when doing builds locally or on packages-test, but when I tried to deploy onto the live site, `docker build` was refusing to build the PHP container image. This turned out to be because `composer` was failing to detect that it was running in a container, not creating the autoload correctly, which then cause `cake` to fail to load BootstrapUI during the build. Thankfully `composer` has a flag that forces it to allow you to run it as root. This PR sets that flag in the build environment so that it shouldn't happen again.