### PR TITLE
Continued fixups

### DIFF
--- a/bropkg/composer.json
+++ b/bropkg/composer.json
@@ -11,7 +11,7 @@
         "cakephp/plugin-installer": "2.0.1",
         "friendsofcake/search": "7.5.0",
         "friendsofcake/bootstrap-ui": "5.1.2",
-        "gregwar/rst": "1.0.6",
+        "doctrine/rst-parser": "0.5.6",
         "josegonzalez/dotenv": "4.0.0",
         "mobiledetect/mobiledetectlib": "4.8.09",
         "psr/http-message": "2.0",

--- a/bropkg/src/View/Helper/MarkdownHelper.php
+++ b/bropkg/src/View/Helper/MarkdownHelper.php
@@ -5,6 +5,8 @@ use Cake\View\Helper;
 use League\CommonMark\Environment\Environment;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkRenderer;
 use League\CommonMark\Extension\Table\Table;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
@@ -34,18 +36,27 @@ class MarkdownHelper extends Helper
          return $this->_converter;
       }
 
+      // The 'heading_permalink' bit below adds anchor links to all heading
+      // elements in the markdown, similar to how GitHub does. This allows
+      // linking to those headers from other places in the README.
       $config = [
           'default_attributes' => [
               Table::class => [
                   'class' => 'table table-bordered'
               ],
           ],
+          'heading_permalink' => [
+              'id_prefix' => '',
+              'aria_hidden' => true,
+              'symbol' => '',
+          ]
       ];
 
       $environment = new Environment($config);
       $environment->addExtension(new CommonMarkCoreExtension());
       $environment->addExtension(new TableExtension());
       $environment->addExtension(new DefaultAttributesExtension());
+      $environment->addExtension(new HeadingPermalinkExtension());
 
       $this->_converter = new MarkdownConverter($environment);
       return $this->_converter;
@@ -80,7 +91,7 @@ class MarkdownHelper extends Helper
                   // Check for whether the URL in this has a scheme on it, something
                   // like https://. Anything without that, we can consider a relative
                   // link.
-                  if (empty(parse_url($matches[1], PHP_URL_SCHEME))) {
+                  if (empty(parse_url($matches[1], PHP_URL_SCHEME)) && !str_starts_with($matches[1], "#")) {
                       $url_path = parse_url($matches[1], PHP_URL_PATH);
 
                       // Github markdown links can have descriptive text after the link itself,

--- a/bropkg/src/View/Helper/MarkdownHelper.php
+++ b/bropkg/src/View/Helper/MarkdownHelper.php
@@ -20,116 +20,113 @@ use League\CommonMark\MarkdownConverter;
  */
 class MarkdownHelper extends Helper
 {
-  protected $_converter;
+    protected $_converter;
 
-  /**
-   * Parse Markdown text to HTML.
-   */
-  public function parse($text)
-  {
-      return $this->_getParser()->convert($text);
-  }
+    /**
+     * Parse Markdown text to HTML.
+     */
+    public function parse($text)
+    {
+        return $this->_getParser()->convert($text);
+    }
 
-  protected function _getParser()
-  {
-      if ( $this->_converter !== null ) {
-         return $this->_converter;
-      }
+    protected function _getParser()
+    {
+        if ( $this->_converter !== null ) {
+            return $this->_converter;
+        }
 
-      // The 'heading_permalink' bit below adds anchor links to all heading
-      // elements in the markdown, similar to how GitHub does. This allows
-      // linking to those headers from other places in the README.
-      $config = [
-          'default_attributes' => [
-              Table::class => [
-                  'class' => 'table table-bordered'
-              ],
-          ],
-          'heading_permalink' => [
-              'id_prefix' => '',
-              'aria_hidden' => true,
-              'symbol' => '',
-          ]
-      ];
+        // The 'heading_permalink' bit below adds anchor links to all heading
+        // elements in the markdown, similar to how GitHub does. This allows
+        // linking to those headers from other places in the README.
+        $config = [
+            'default_attributes' => [
+                Table::class => [
+                    'class' => 'table table-bordered'
+                ],
+            ],
+            'heading_permalink' => [
+                'id_prefix' => '',
+                'aria_hidden' => true,
+                'symbol' => '',
+            ]
+        ];
 
-      $environment = new Environment($config);
-      $environment->addExtension(new CommonMarkCoreExtension());
-      $environment->addExtension(new TableExtension());
-      $environment->addExtension(new DefaultAttributesExtension());
-      $environment->addExtension(new HeadingPermalinkExtension());
+        $environment = new Environment($config);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new TableExtension());
+        $environment->addExtension(new DefaultAttributesExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
 
-      $this->_converter = new MarkdownConverter($environment);
-      return $this->_converter;
-  }
+        $this->_converter = new MarkdownConverter($environment);
+        return $this->_converter;
+    }
 
-  /**
-   * Canonify Markdown content.
-   *
-   * @param string $input Markdown to be parsed.
-   * @param string $url The package URL for this Markdown.
-   * @return bool|string
-   */
-  public function canonify($input, $url)
-  {
-      // TODO: It'd really be better do this when parsing the package data instead
-      // of doing this every time we load the package page.
+    /**
+     * Canonify Markdown content.
+     *
+     * @param string $input Markdown to be parsed.
+     * @param string $url The package URL for this Markdown.
+     * @return bool|string
+     */
+    public function canonify(string $input, string $url)
+    {
+        // TODO: It'd really be better do this when parsing the package data instead
+        // of doing this every time we load the package page.
 
-      if (!is_string($input)) {
-          return false;
-      }
-      if (strcasecmp(parse_url($url, PHP_URL_HOST), "github.com") == 0) {
-          /* If the url passed is to github.com, we want to rewrite the relative
-           * links so that they link to github. For images, we want to link to
-           * raw.githubcontent.com so it will load the actual image instead. Other
-           * links can be to the repo view. There isn't a good way to look up the
-           * MIME type for the paths, so just assume anything ending in .jpg or
-           * .png is an image, and anything else isn't.
-           */
-          $input = preg_replace_callback(
-              '|\]\(([^)]*)\)|',
-              function ($matches) use ($url) {
-                  // Check for whether the URL in this has a scheme on it, something
-                  // like https://. Anything without that, we can consider a relative
-                  // link.
-                  if (empty(parse_url($matches[1], PHP_URL_SCHEME)) && !str_starts_with($matches[1], "#")) {
-                      $url_path = parse_url($matches[1], PHP_URL_PATH);
+        if (strcasecmp(parse_url($url, PHP_URL_HOST), "github.com") == 0) {
+            /* If the url passed is to github.com, we want to rewrite the relative
+             * links so that they link to github. For images, we want to link to
+             * raw.githubcontent.com so it will load the actual image instead. Other
+             * links can be to the repo view. There isn't a good way to look up the
+             * MIME type for the paths, so just assume anything ending in .jpg or
+             * .png is an image, and anything else isn't.
+             */
+            $input = preg_replace_callback(
+                '|\]\(([^)]*)\)|',
+                function ($matches) use ($url) {
+                    // Check for whether the URL in this has a scheme on it, something
+                    // like https://. Anything without that, we can consider a relative
+                    // link.
+                    if (empty(parse_url($matches[1], PHP_URL_SCHEME)) && !str_starts_with($matches[1], "#")) {
+                        $url_path = parse_url($matches[1], PHP_URL_PATH);
 
-                      // Github markdown links can have descriptive text after the link itself,
-                      // separated by a space from the link. parse_url and path_info don't
-                      // know this and so they return the whole thing. Split off just the first
-                      // part as the extension.
-                      $extension = explode(" ", pathinfo($url_path, PATHINFO_EXTENSION))[0];
+                        // Github markdown links can have descriptive text after the link itself,
+                        // separated by a space from the link. parse_url and path_info don't
+                        // know this and so they return the whole thing. Split off just the first
+                        // part as the extension.
+                        $extension = explode(" ", pathinfo($url_path, PATHINFO_EXTENSION))[0];
 
-                      if (strcasecmp($extension, "jpg") == 0 ||
-                          strcasecmp($extension, "jpeg") == 0 ||
-                          strcasecmp($extension, "png") == 0 ||
-                          strcasecmp($extension, "gif") == 0 ||
-                          strcasecmp($extension, "webp") == 0) {
-                          $url = preg_replace('|://github\.com/|', '://raw.githubusercontent.com/', $url);
-                          return "](" . $url . "/master/" . $matches[1] . ")";
-                      }
+                        if (strcasecmp($extension, "jpg") == 0 ||
+                            strcasecmp($extension, "jpeg") == 0 ||
+                            strcasecmp($extension, "png") == 0 ||
+                            strcasecmp($extension, "gif") == 0 ||
+                            strcasecmp($extension, "webp") == 0) {
+                            $url = preg_replace('|://github\.com/|', '://raw.githubusercontent.com/', $url);
+                                return "](" . $url . "/master/" . $matches[1] . ")";
+                        }
 
-                      return "](" . $url . "/blob/master/" . $matches[1] . ")";
-                  }
+                        return "](" . $url . "/blob/master/" . $matches[1] . ")";
+                    }
 
-                  /* This already links to an absolute URL: keep as-is. */
-                  return $matches[0];
-              },
-              $input
-          );
-      } else {
-          /* For other sites simply remove the link, keeping its anchor text. We
-           * don't know where to direct the link.
-           */
-          $input = preg_replace_callback(
-              '|\[([^\]]*)\]\([^)]*\)|',
-              function ($matches) {
-                  return $matches[1];
-              },
-              $input
-          );
-      }
+                    /* This already links to an absolute URL: keep as-is. */
+                    return $matches[0];
+                },
+                $input
+            );
+        } else {
+            /* For other sites simply remove the link, keeping its anchor text. We
+             * don't know where to direct the link.
+             */
+            $input = preg_replace_callback(
+                '|\[([^\]]*)\]\([^)]*\)|',
+                function ($matches) {
+                    return $matches[1];
+                },
+                $input
+            );
+        }
 
-      return $input;
-  }
+        return $input;
+    }
 }

--- a/bropkg/src/View/Helper/RstMarkupHelper.php
+++ b/bropkg/src/View/Helper/RstMarkupHelper.php
@@ -2,7 +2,7 @@
 namespace App\View\Helper;
 
 use Cake\View\Helper;
-use Gregwar\RST\Parser;
+use Doctrine\RST\Parser;
 
 /**
  * Rst markup helper
@@ -11,22 +11,30 @@ use Gregwar\RST\Parser;
  */
 class RstMarkupHelper extends Helper
 {
-  /**
-   * Parse RST markup input to HTML.
-   *
-   * @param string $input RST markup to be parsed.
-   * @return bool|string
-   */
-  public function transform($input)
-  {
-      if (!is_string($input)) {
-          return false;
-      }
+    protected $_parser;
 
-      if (!isset($this->parser)) {
-          $this->parser = new \Gregwar\RST\Parser;
-      }
+    /**
+     * Parse RST markup input to HTML.
+     *
+     * @param string $text RST markup to be parsed.
+     * @return string
+     */
+    public function parse(string $text)
+    {
+        $parsed = $this->_getParser()->parse($text);
+        return $parsed->render();
+    }
 
-      return $this->parser->parse($input);
-  }
+    /**
+     * Creates a static instance of the RST parser.
+     */
+    protected function _getParser()
+    {
+        if ( $this->_parser !== null ) {
+            return $this->_parser;
+        }
+
+        $this->_parser = new Parser();
+        return $this->_parser;
+    }
 }

--- a/bropkg/templates/Error/error400.php
+++ b/bropkg/templates/Error/error400.php
@@ -8,7 +8,7 @@ if (Configure::read('debug')) :
     $this->layout = 'dev_error';
 
     $this->assign('title', $message);
-    $this->assign('templateName', 'error400.ctp');
+    $this->assign('templateName', 'error400.php);
 
     $this->start('file');
 ?>

--- a/bropkg/templates/Error/error500.php
+++ b/bropkg/templates/Error/error500.php
@@ -8,7 +8,7 @@ if (Configure::read('debug')) :
     $this->layout = 'dev_error';
 
     $this->assign('title', $message);
-    $this->assign('templateName', 'error500.ctp');
+    $this->assign('templateName', 'error500.php');
 
     $this->start('file');
 ?>

--- a/bropkg/templates/Packages/view.php
+++ b/bropkg/templates/Packages/view.php
@@ -101,7 +101,7 @@ function strClean($str) {
           <div class="col border border-1 rounded-3 bg-white p-1">
             <article class="markdown-body entry-content">
             <?php if (preg_match('/\.rst$/', $package->readme_name)): ?>
-                <?= $this->RstMarkup->transform($package->readme); ?>
+                <?= $this->RstMarkup->parse($package->readme); ?>
             <?php else: ?>
                 <?= $this->Markdown->parse($this->Markdown->canonify($package->readme, $package->url)); ?>
             <?php endif; ?>

--- a/bropkg/templates/Packages/view.php
+++ b/bropkg/templates/Packages/view.php
@@ -103,7 +103,7 @@ function strClean($str) {
             <?php if (preg_match('/\.rst$/', $package->readme_name)): ?>
                 <?= $this->RstMarkup->parse($package->readme); ?>
             <?php else: ?>
-                <?= $this->Markdown->parse($this->Markdown->canonify($package->readme, $package->url)); ?>
+                <?= $this->Markdown->parse($package->readme, $package->url); ?>
             <?php endif; ?>
             </article>
           </div>

--- a/bropkg/templates/layout/default.php
+++ b/bropkg/templates/layout/default.php
@@ -12,7 +12,7 @@ $this->request->getSession()->write('lastpage', $lastpage);
     <?= $this->Html->charset() ?>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <?= $this->Html->meta('icon') ?>
+    <? echo $this->Html->meta('favicon.ico', '/favicon.ico', ['type' => 'icon']); ?>
     <title>
         <?= $pageDescription ?>:
         <?= $this->fetch('title') ?>


### PR DESCRIPTION
This PR should fix all of the remaining warnings from debug.log from the last few days on the live site.

- The metron-bro-plugin-kafka package uses anchor links in its readme to link to different places in the readme. The markdown canonifier throws a deprecation warning in debug log because those links aren't handled correctly. Add the `HeadingPermalinkExtension` to the canonifier to add the anchors to the output, and fix the handling of the anchor links to not result in the debug log.
- Fix the paths to the error template files (in the error template files). I don't know what this actually does for us. I should probably revisit those files at some point to see if we can make them actually useful.
- Fix the path to the favicon in the header meta tags so that we don't get a bunch of 404s in error.log.
- Switch to a different ReST markup parser that has newer releases, which fixes a bunch of debug.log warnings with the old one.
- Fix parsing of `<img>` tags in Markdown READMEs like we do for the `[]()` format for so that we link to the right image files. I noticed this while looking at the JA4 package, which was missing its header image.